### PR TITLE
Add Firebase API key files to .gitignore for Android and iOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,7 @@
 !**/ios/**/default.pbxuser
 !**/ios/**/default.perspectivev3
 !/packages/flutter_tools/test/data/dart_dependencies_test/**/.packages
+
+# Firebase related
+GoogleService-Info.plist
+google-services.json


### PR DESCRIPTION
Related issue: https://github.com/shrop/contenta_flutter/issues/6